### PR TITLE
Remove unnecessary autoloads

### DIFF
--- a/src/DaemonServer.php
+++ b/src/DaemonServer.php
@@ -10,8 +10,6 @@
 
 namespace Mapepire;
 
-require_once 'vendor/autoload.php';
-
 /**
  * DaemonServer structure represents factors to initialize a SQLJob instance.
  */

--- a/src/SQLJob.php
+++ b/src/SQLJob.php
@@ -10,8 +10,6 @@
 
 namespace Mapepire;
 
-require_once 'vendor/autoload.php';
-
 /**
  * SQLJob is a client to the Mapepire Server
  * @see https://mapepire-ibmi.github.io/


### PR DESCRIPTION
I have a lot more cleaned up, but there's still more to do. Dotenv needs to be removed. I also don't think we should be putting class properties at the bottom of the class. That is against PSR standards, and we should certainly be following PSR.

I went ahead and separated the autoload cleanup into this branch. I'll try to get the rest done ASAP in my other branch.