### PR TITLE
Cleanup 2

### DIFF
--- a/src/DaemonServer.php
+++ b/src/DaemonServer.php
@@ -26,17 +26,17 @@ class DaemonServer implements \Stringable
     /**
      * Summary of __construct
      * @param string $host Mapepire server host
-     * @param int $port Mapepire server port
      * @param string $user Userid to authorize on Mapepire server
      * @param string $password Password to authorize on Mapepire server
+     * @param int $port Mapepire server port
      * @param bool $verifyHostCert .IFF. false accept self-signed, default true
      * @param bool $verifyHostName .IFF. true verify the host name
      */
     public function __construct(
         string $host = self::DEFAULT_HOST_NAME,
-        int $port = self::DEFAULT_PORT,
         string $user = null,
         string $password = null,
+        int $port = self::DEFAULT_PORT,
         bool $verifyHostCert = self::DEFAULT_VERIFY_HOST_CERT,
         bool $verifyHostName = self::DEFAULT_VERIFY_HOST_NAME,
         int $timeout = self::DEFAULT_TIMEOUT,

--- a/src/DaemonServer.php
+++ b/src/DaemonServer.php
@@ -24,6 +24,60 @@ class DaemonServer implements \Stringable
     const DEFAULT_PERSISTENCE = false;
 
     /**
+     * DNS or IP of Mapepire server
+     * @var ?string
+     */
+    public ?string $host;
+
+    /**
+     * port number of Mapepire host
+     * @var ?int
+     */
+    public ?int $port;
+
+    /**
+     * User profile for IBM i Db2
+     * @var ?string
+     */
+    public ?string $user;
+
+    /**
+     * Password for IBM i Db2
+     * @var ?string
+     */
+    public ?string $password;
+
+    /**
+     * verifyHostCert .IFF. false accept snakeoil cert
+     * @var bool
+     */
+    public ?bool $verifyHostCert;
+
+    /**
+     * verifyHostName .IFF. true
+     * @var ?bool
+     */
+    public ?bool $verifyHostName;
+
+    /**
+     * Connection timeout
+     * @var ?int
+     */
+    public ?int $timeout; // default 60 seconds
+
+    /**
+     * Communication frame size
+     * @var ?int
+     */
+    public ?int $framesize; // default 4096 bytes
+
+    /**
+     * Should attempt connection persistent
+     * @var ?bool
+     */
+    public ?bool $persistent;    // If client should attempt persistent connection
+
+    /**
      * Summary of __construct
      * @param string $host Mapepire server host
      * @param string $user Userid to authorize on Mapepire server
@@ -121,49 +175,4 @@ class DaemonServer implements \Stringable
         );
         return $DaemonServer;
     }
-    /**
-     * DNS or IP of Mapepire server
-     * @var ?string
-     */
-    public ?string $host;
-    /**
-     * port number of Mapepire host
-     * @var ?int
-     */
-    public ?int $port;
-    /**
-     * User profile for IBM i Db2
-     * @var ?string
-     */
-    public ?string $user;
-    /**
-     * Password for IBM i Db2
-     * @var ?string
-     */
-    public ?string $password;
-    /**
-     * verifyHostCert .IFF. false accept snakeoil cert
-     * @var bool
-     */
-    public ?bool $verifyHostCert;
-    /**
-     * verifyHostName .IFF. true
-     * @var ?bool
-     */
-    public ?bool $verifyHostName;
-    /**
-     * Connection timeout
-     * @var ?int
-     */
-    public ?int $timeout; // default 60 seconds
-    /**
-     * Communication frame size
-     * @var ?int
-     */
-    public ?int $framesize; // default 4096 bytes
-    /**
-     * Should attempt connection persistent
-     * @var ?bool
-     */
-    public ?bool $persistent;    // If client should attempt persistent connection
 }

--- a/src/DaemonServer.php
+++ b/src/DaemonServer.php
@@ -13,7 +13,7 @@ namespace Mapepire;
 /**
  * DaemonServer structure represents factors to initialize a SQLJob instance.
  */
-class DaemonServer implements \Stringable
+class DaemonServer
 {
     const DEFAULT_HOST_NAME = 'localhost';
     const DEFAULT_PORT = 8076;
@@ -27,55 +27,55 @@ class DaemonServer implements \Stringable
      * DNS or IP of Mapepire server
      * @var ?string
      */
-    public ?string $host;
+    private ?string $host;
 
     /**
      * port number of Mapepire host
      * @var ?int
      */
-    public ?int $port;
+    private ?int $port;
 
     /**
      * User profile for IBM i Db2
      * @var ?string
      */
-    public ?string $user;
+    private ?string $user;
 
     /**
      * Password for IBM i Db2
      * @var ?string
      */
-    public ?string $password;
+    private ?string $password;
 
     /**
      * verifyHostCert .IFF. false accept snakeoil cert
      * @var bool
      */
-    public ?bool $verifyHostCert;
+    private ?bool $verifyHostCert;
 
     /**
      * verifyHostName .IFF. true
      * @var ?bool
      */
-    public ?bool $verifyHostName;
+    private ?bool $verifyHostName;
 
     /**
      * Connection timeout
      * @var ?int
      */
-    public ?int $timeout; // default 60 seconds
+    private ?int $timeout; // default 60 seconds
 
     /**
      * Communication frame size
      * @var ?int
      */
-    public ?int $framesize; // default 4096 bytes
+    private ?int $framesize; // default 4096 bytes
 
     /**
      * Should attempt connection persistent
      * @var ?bool
      */
-    public ?bool $persistent;    // If client should attempt persistent connection
+    private ?bool $persistent;    // If client should attempt persistent connection
 
     /**
      * Summary of __construct
@@ -108,71 +108,93 @@ class DaemonServer implements \Stringable
         $this->persistent = $persistent;
     }
 
-    /**
-     * @override
-     * @return string String representation of DaemonServer instance
-     */
-    public function __toString(): string
+    public function getHost(): ?string
     {
-        $result = "Mapepire\DaemonServer" . PHP_EOL
-            . "host: $this->host" . PHP_EOL
-            . "port: $this->port" . PHP_EOL
-            . "user: $this->user" . PHP_EOL
-            . "password: " . ($this->password ? "(hidden)" : "(no password was provided)") . PHP_EOL
-            . "verifyHostCert: $this->verifyHostCert" . PHP_EOL
-            . "verifyHostName: $this->verifyHostName" . PHP_EOL
-            . "timeout: $this->timeout" . PHP_EOL
-            . "framesize: $this->framesize" . PHP_EOL
-            . "persistent: $this->persistent" . PHP_EOL
-        ;
-        return $result;
+        return $this->host;
     }
 
-    /**
-     * Load the .env file if any
-     * @param string $dir Directory .env file found in, default '.'
-     * @return object the dotenv object
-     */
-    public static function loadDotEnv(string $dir = '.'): object
+    public function setHost(?string $host): void
     {
-        $dotenv = \Dotenv\Dotenv::createImmutable(paths: $dir);
-        $dotenv->safeLoad();
-        return $dotenv;
+        $this->host = $host;
     }
 
-    /**
-     * Instance a DaemonServer structure from a .env file.
-     * - Loads the dotenv object.
-     * - Chooses defaults if the variables do not appear in the $_ENV.
-     *   - MAPEPIRE_SERVER localhost
-     *   - MAPEPIRE_PORT 8076
-     *   - MAPEPIRE_VERIFY_HOST_CERT true
-     *   - MAPEPIRE_VERIFY_HOST_NAME true
-     * No defaults for
-     * - MAPEPIRE_DB_USER
-     * - MAPEPIRE_DB_PASS
-     * See the .env.sample in the root of the project
-     * @param string $dir directory containing the .env file (if any such file)
-     * @return DaemonServer instance
-     */
-    public static function DaemonServerFromDotEnv(string $dir = '.'): DaemonServer
+    public function getPort(): ?int
     {
-        self::loadDotEnv(dir: $dir);
-        $DaemonServer = new DaemonServer(
-            host: array_key_exists(key: 'MAPEPIRE_SERVER', array: $_ENV) ? $_ENV['MAPEPIRE_SERVER'] : self::DEFAULT_HOST_NAME,
-            port: array_key_exists(key: 'MAPEPIRE_PORT', array: $_ENV) ? (int) $_ENV['MAPEPIRE_PORT'] : self::DEFAULT_PORT,
-            user: $_ENV['MAPEPIRE_DB_USER'],
-            password: $_ENV['MAPEPIRE_DB_PASS'],
-            verifyHostCert: array_key_exists(key: 'MAPEPIRE_VERIFY_HOST_CERT', array: $_ENV)
-            ? strtolower(string: $_ENV['MAPEPIRE_VERIFY_HOST_CERT']) == 'true'
-            : self::DEFAULT_VERIFY_HOST_CERT,
-            verifyHostName: array_key_exists(key: 'MAPEPIRE_VERIFY_HOST_NAME', array: $_ENV)
-            ? strtolower(string: $_ENV['MAPEPIRE_VERIFY_HOST_NAME']) == 'true'
-            : self::DEFAULT_VERIFY_HOST_NAME,
-            timeout: array_key_exists(key: 'MAPEPIRE_TIMEOUT', array: $_ENV) ? (int) $_ENV['MAPEPIRE_TIMEOUT'] : self::DEFAULT_TIMEOUT,
-            framesize: array_key_exists(key: 'MAPEPIRE_FRAMESIZE', array: $_ENV) ? (int) $_ENV['MAPEPIRE_FRAMESIZE'] : self::DEFAULT_FRAMESIZE,
-            persistent: array_key_exists(key: 'MAPEPIRE_PERSISTENCE', array: $_ENV) ? (int) $_ENV['MAPEPIRE_DEFAULT_PERSISTENCE'] : self::DEFAULT_PERSISTENCE
-        );
-        return $DaemonServer;
+        return $this->port;
+    }
+
+    public function setPort(?int $port): void
+    {
+        $this->port = $port;
+    }
+
+    public function getUser(): ?string
+    {
+        return $this->user;
+    }
+
+    public function setUser(?string $user): void
+    {
+        $this->user = $user;
+    }
+
+    public function getPassword(): ?string
+    {
+        return $this->password;
+    }
+
+    public function setPassword(?string $password): void
+    {
+        $this->password = $password;
+    }
+
+    public function getVerifyHostCert(): ?bool
+    {
+        return $this->verifyHostCert;
+    }
+
+    public function setVerifyHostCert(?bool $verifyHostCert): void
+    {
+        $this->verifyHostCert = $verifyHostCert;
+    }
+
+    public function getVerifyHostName(): ?bool
+    {
+        return $this->verifyHostName;
+    }
+
+    public function setVerifyHostName(?bool $verifyHostName): void
+    {
+        $this->verifyHostName = $verifyHostName;
+    }
+
+    public function getTimeout(): ?int
+    {
+        return $this->timeout;
+    }
+
+    public function setTimeout(?int $timeout): void
+    {
+        $this->timeout = $timeout;
+    }
+
+    public function getFramesize(): ?int
+    {
+        return $this->framesize;
+    }
+
+    public function setFramesize(?int $framesize): void
+    {
+        $this->framesize = $framesize;
+    }
+
+    public function getPersistent(): ?bool
+    {
+        return $this->persistent;
+    }
+
+    public function setPersistent(?bool $persistent): void
+    {
+        $this->persistent = $persistent;
     }
 }

--- a/src/SQLJob.php
+++ b/src/SQLJob.php
@@ -33,9 +33,9 @@ class SQLJob
         $this->client->addHeader("Authorization", "Basic " . self::credentialEncoder($server->getUser(), $server->getPassword()));
         $this->client->addMiddleware(new CloseHandler());
         $this->client->addMiddleware(new PingResponder());
-//        $this->websocket_client->setTimeout = $this->timeout;
-//        $this->websocket_client->setFrameSize = $this->framesize;
-//        $this->websocket_client->setPersistent = $this->persistent;
+        $this->client->setTimeout($server->getTimeout());
+        $this->client->setFrameSize($server->getFrameSize());
+        $this->client->setPersistent($server->getPersistent());
     }
 
     /**

--- a/src/SQLJob.php
+++ b/src/SQLJob.php
@@ -29,7 +29,7 @@ class SQLJob
     public function connect(DaemonServer $server): void
     {
         $this->server = $server;
-        $this->client = new Client($this->genURI($server->getHost(), $server->getPort()));
+        $this->client = new Client(new Uri("wss://{$server->getHost()}:{$server->getPort()}/db/"));
         $this->client->addHeader("Authorization", "Basic " . self::credentialEncoder($server->getUser(), $server->getPassword()));
         $this->client->addMiddleware(new CloseHandler());
         $this->client->addMiddleware(new PingResponder());
@@ -63,16 +63,6 @@ class SQLJob
     public function close(): void
     {
         $this->client->close();
-    }
-
-    /**
-     * Formulate the URI for the connection
-     * @return string the uri
-     */
-    private function genURI(string $host, int $port): Uri
-    {
-        $uri_string = "wss://$host:$port/db/";
-        return new Uri($uri_string);
     }
 
     /**


### PR DESCRIPTION
This cleans up some confusing architecture, bad practices, and bugs within the base classes and their methods.

PHP PSR, the community standards, say to have class properties at the very top. That has been cleaned up.

DotEnv should not be used within libraries, unless for **very** specific use cases, which this library does not have. The user can use DotEnv if they like, when passing information to define DaemonServer.

Stringable is unnecessary for these classes, and it just adds more lines of code and another piece to maintain.

Named parameters, `function(parameterName: 'value')` is a very new feature to PHP. We do not want to alienate older versions of PHP, especially on a platform like IBM i.

SQLJob, according to the [Mapepire reference architecture](https://mapepire-ibmi.github.io/reference/maintenance/referencearchitecture/), should not have a construct. It especially shouldn't have one that mirrors DaemonServer. I restructured SQLJob to rely on `->connect()` to get the DaemonServer, as is recommended.

There were also a lot of bugs I encountered while testing. Some class methods weren't passing the proper data types, things like that. The order of parameters for DaemonServer didn't make much sense, as the port is going to be default 99% of the time, so it shouldn't be the 2nd parameter. I've cleaned a lot of that up.

Still more to go, but this is a good starting point.
