### PR TITLE
Retrieve Certificate from server for authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Regardless of connection method, the client performs authentication with informa
 3. password (required) - the password of the user profile
 4. port (optional) - the server port, defaults to 8076
 5. ignoreUnauthorized (optional) - a boolean value determining whether to ignore if a user in unauthorized, defaults to false
-6. ca (optional) - the path to a certificate determining that a user is authorized. If (5) is false, this is required. 
+6. ca (optional) - the path to a certificate determining that a user is authorized. If this is not provided and (5) is false, the client will attempt to retrieve one from the server. 
 
 ## Getting a response
 

--- a/src/SQLJob.php
+++ b/src/SQLJob.php
@@ -87,9 +87,13 @@ class SQLJob
             'verify_peer'       => $verify,
             'verify_peer_name'  => $verify,
         ];
-        if ($verify && is_string($server->ca) && $server->ca !== '')
-            $sslContext['cafile'] = $server->ca;
-
+        if ($verify) {
+            if (empty($server->getCa())) {
+                $server->retrieveCertificate();
+            }
+            $sslContext['peer_name'] = $server->host;
+            $sslContext['cafile']    = $server->getCa();
+        }
         $socket->setContext(["ssl" => $sslContext]);
         return $socket;
     }


### PR DESCRIPTION
Create and use DaemonServer::retrieveCertificate() to obtain certificate from server
Change DamonServer::ca to private and add getter

These changes are meant to mirror the approach used in mapepire-python. 